### PR TITLE
remove variables for aws access keys

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,8 @@
   - name: create nodes for non-cluster roles
     action:
       module: ec2
-      aws_access_key: '{{aws_access_key}}'
-      aws_secret_key: '{{aws_secret_key}}'
+#      aws_access_key: '{{aws_access_key}}'
+#      aws_secret_key: '{{aws_secret_key}}'
       region: '{{item.value.region}}'
       zone: '{{item.value.zone}}'
       spot_price: '{{item.value.edge_node_price}}'
@@ -28,11 +28,15 @@
     register: external
     with_dict: ec2_regions
 
+  - name: update inventory file
+    template: src=inventory.py.j2 dest=./inventory.py mode=0700 backup=no
+
+
   - name: create cluster nodes
     action:
       module: ec2
-      aws_access_key: '{{aws_access_key}}'
-      aws_secret_key: '{{aws_secret_key}}'
+#      aws_access_key: '{{aws_access_key}}'
+#      aws_secret_key: '{{aws_secret_key}}'
       region: '{{item.value.region}}'
       zone: '{{item.value.zone}}'
       spot_price: '{{item.value.cluster_node_price}}'
@@ -55,7 +59,7 @@
     register: ec2_cluster
     with_dict: ec2_regions
 
-  - name: write an inventory file
+  - name: update inventory file
     template: src=inventory.py.j2 dest=./inventory.py mode=0700 backup=no
 
   #- name: add the new hosts to inventory

--- a/templates/inventory.py.j2
+++ b/templates/inventory.py.j2
@@ -4,35 +4,41 @@ import argparse
 import json
 
 def ansible_inventory():
-	last_node_index = {{ec2_cluster.results|length}}
-
 	hostvars = {
+{% if ec2_cluster is defined %}
 	{%- for result in ec2_cluster.results %}
 	    {%- for instance in result.instances %}
 	      "{{instance.private_ip}}": { "instance_id": "{{instance.id}}" },
 	    {% endfor %}
 	{% endfor %}
+{% endif %}
+{% if external is defined %}
 	{%- for result in external.results %}
 	    {%- for instance in result.instances %}
 	      "{{instance.private_ip}}": { "instance_id": "{{instance.id}}" },
 	    {% endfor %}
 	{% endfor %}
+{% endif %}
         }
 
 	cluster = [
+{% if ec2_cluster is defined %}
 	{%- for result in ec2_cluster.results %}
 	    {%- for instance in result.instances %}
 	      "{{instance.private_ip}}",
 	    {% endfor %}
 	{% endfor %}
+{% endif %}
 	  ]
 
 	edge = [
+{% if external is defined %}
 	{%- for result in external.results %}
 	    {%- for instance in result.instances %}
 	      "{{instance.private_ip}}",
 	    {% endfor %}
 	{% endfor %}
+{% endif %}
 	  ]
 
 	# Use python list slicing to define the hosts.


### PR DESCRIPTION
remove variables in favor of using awscli/boto central config (.aws/credentials)
